### PR TITLE
Modifications so that MIDI can be loaded using webpack

### DIFF
--- a/build/MIDI.js
+++ b/build/MIDI.js
@@ -1545,14 +1545,6 @@ if (typeof MIDI === 'undefined') MIDI = {};
 		xhr.send(data);
 		return xhr;
 	};
-
-	/// NodeJS
-	if (typeof module !== 'undefined' && module.exports) {
-		var NodeFS = require('fs');
-		XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
-		module.exports = root.util.request;
-	}
-
 })(MIDI);
 /*
 	-----------------------------------------------------------

--- a/inc/shim/Base64binary.js
+++ b/inc/shim/Base64binary.js
@@ -79,3 +79,5 @@ var Base64Binary = {
 		return uarray;	
 	}
 };
+
+module.exports = Base64Binary;


### PR DESCRIPTION
There was an incorrect check for NodeJs environment in the MIDI.js. This PR fixes that along with exporting the `Base64Binary` object so, that it can be loaded using webpack.